### PR TITLE
Address inputs validate

### DIFF
--- a/src/Controllers/FrontController.php
+++ b/src/Controllers/FrontController.php
@@ -1258,6 +1258,30 @@ class FrontController extends Controller
                     // Identificar al usuario para guardar sus datos.
                     $user->orders()->save($order);
 
+                    // GUARDAR LA DIRECCIÓN
+                    if ($request->save_address == 'true') {
+
+                        $check = UserAddress::where('street', $street)->count();
+
+                        if ($check == NULL || $check == 0) {
+                            $address = new UserAddress;
+                            $address->name = 'Compra_Paypal_' . $order->id;
+                            $address->user_id = $user->id;
+                            $address->street = $street;
+                            $address->street_num = $street_num;
+                            $address->postal_code = $postal_code;
+                            $address->city = $city;
+                            $address->country = $country;
+                            $address->state = $state;
+                            $address->phone = $phone;
+                            $address->suburb = $suburb;
+                            $address->references = $references;
+                            $address->is_billing = false;
+
+                            $address->save();
+                        }
+                    }
+
                     // Enviar al usuario a confirmar su compra en el panel de Paypal
                     return redirect()->away($payment->getApprovalLink());
 
@@ -1353,6 +1377,7 @@ class FrontController extends Controller
 
         // GUARDAR LA DIRECCIÓN
         if ($request->save_address == 'true') {
+
             $check = UserAddress::where('street', $street)->count();
 
             if ($check == NULL || $check == 0) {

--- a/src/resources/views/front/werkn-backbone-bootstrap/checkout/utilities/_order_address.blade.php
+++ b/src/resources/views/front/werkn-backbone-bootstrap/checkout/utilities/_order_address.blade.php
@@ -23,7 +23,7 @@
 
                     <div class="col-6 col-md-3">
                         <div class="mb-3">
-                            <label class="form-label" for="last-name">Núm. <span class="text-danger">*</span></label>
+                            <label class="form-label" for="last-name">Num <span class="text-danger">*</span></label>
                             <input type="text" class="form-control" id="street_num" name="street_num" value="{{ $address->street_num ?? '' }}" required="" />
                         </div>
                     </div>
@@ -120,91 +120,21 @@
                     </label>
                 </div>
             </div>
-            <div class="card-body" style="display:none;">
-                <div class="row">
-                    <div class="col-md-7">
-                        <div class="mb-3">
-                            <label class="form-label" for="last-name">Calle <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="street" name="street" value="{{ $address->street ?? '' }}" required="" />
-                        </div>
-                    </div>
 
-                    <div class="col-md-3">
-                        <div class="mb-3">
-                            <label class="form-label" for="last-name">Num <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="street_num" name="street_num" value="{{ $address->street_num ?? '' }}" required="" />
-                        </div>
-                    </div>
+            <div id="addressCard_{{ $address->id }}" class="card-body card-body-old-add" style="display:none;">
+                <input type="text" class="form-control"  name="street" value="{{ $address->street ?? '' }}" required="" disabled/>
+                <input type="text" class="form-control"  name="street_num" value="{{ $address->street_num ?? '' }}" required="" disabled/>
+                <input type="text" class="form-control"  name="int_num" value="{{ $address->int_num ?? '' }}" disabled/>
+                <input type="text" class="form-control"  value="{{ $address->suburb ?? '' }}" required="" disabled/>
+                <input type="text" class="form-control" id="postalCode_{{ $address->id }}" name="postal_code" value="{{ $address->postal_code ?? '' }}" required="" autocomplete="off" disabled/>
+                <input type="text" class="form-control" name="country" value="{{ $address->country ?? '' }}" required="" autocomplete="off" disabled/>
+                <input type="text" class="form-control" name="state" value="{{ $address->state ?? '' }}" required="" disabled/>
+                <input type="text" class="form-control" name="city" value="{{ $address->city ?? '' }}" required="" disabled/>
+                <input type="text" class="form-control" name="suburb" value="{{ $address->suburb ?? '' }}" required="" disabled/>
 
-                    <div class="col-md-2">
-                        <div class="mb-3">
-                            <label class="form-label" for="last-name">Int </label>
-                            <input type="text" class="form-control" id="int_num" name="int_num" value="{{ $address->int_num ?? '' }}" />
-                        </div>
-                    </div>
-
-                    <div class="col-md-6">
-                        <div class="mb-3">
-                            <label class="form-label" for="zip">Colonia / Fraccionamiento <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="suburb" name="suburb" value="{{ $address->suburb ?? '' }}" required="" />
-                        </div>
-                    </div>
-
-                    <div class="col-md-6">
-                        <div class="mb-3">
-                            <label class="form-label" for="zip">Código Postal <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="postal_code" name="postal_code" value="{{ $address->postal_code ?? '' }}" required="" autocomplete="off" />
-
-                            <small class="postal_code_notice text-danger mt-1"></small>
-                        </div>
-                    </div>
-
-                    <div class="col-md-4">
-                        <div class="mb-3">
-                            <label class="form-label" for="country">País <span class="text-danger">*</span></label>
-                            <select class="form-control" id="country" name="country">
-                                <option value="México" selected="">México</option>
-                            </select>
-                        </div>
-                    </div>
-
-                    <div class="col-md-4">
-                        <div class="mb-3">
-                            <label class="form-label" for="state">Estado <span class="text-danger">*</span></label>
-
-                            <input type="text" class="form-control" id="state" name="state" value="{{ $address->state ?? '' }}" required="" />
-                            {{--
-                            @php
-                                $states = Nowyouwerkn\WeCommerce\Models\State::all();
-                            @endphp
-                            <select class="form-control" id="state" name="state" data-parsley-trigger="change" required="">
-                                @foreach($states as $state)
-                                    @if(!empty($address))
-                                        <option {{ ($state->name == $address->state) ? 'selected' : '' }} value="{{ $state->name }}">{{ $state->name }}</option>
-                                    @else
-                                        <option value="{{ $state->name }}">{{ $state->name }}</option>
-                                    @endif
-                                @endforeach
-                            </select>
-                            --}}
-                        </div>
-                    </div>
-
-                    <div class="col-md-4">
-                        <div class="mb-3">
-                            <label class="form-label" for="city">Ciudad / Municipio <span class="text-danger">*</span></label>
-                            <input type="text" class="form-control" id="city" name="city" value="{{ $address->city ?? '' }}" required="" />
-                        </div>
-                    </div>
-
-                    <div class="col-md-12">
-                        <div class="mb-3">
-                            <label class="form-label" for="zip">Referencias <span class="text-danger">*</span></label>
-                            <textarea class="form-control" id="references" required="" name="references" rows="3"></textarea>
-                        </div>
-                    </div>
-                </div>
+                <textarea class="form-control" required="" name="references" rows="3">{{ $address->references }}</textarea>
             </div>
+
         </div>
         @endforeach
         <div class="card">
@@ -218,8 +148,7 @@
                 </div>
 
                <label>
-                <input type="hidden" name="save_address" value="false">
-                <input type="checkbox" name="save_address" value="true">  Guardar esta dirección para después</label>
+                <input type="checkbox" name="save_address" value="false" id="save-address">  Guardar esta dirección para después</label>
             </div>
             <div class="card-body card-body-new-add" id="new_address_body">
                 <div class="row">
@@ -381,4 +310,51 @@
         }
     });
 </script>
+
+
+@auth
+@foreach(Auth::user()->addresses->take(3) as $address)
+<script>
+    $('#addressRadio_{{ $address->id }}').on('click', function(){
+
+        if($('#addressRadio_{{ $address->id }}').attr('checked', 'true')){
+
+
+            $(".card-body-old-add .form-control").attr('disabled', 'disabled');
+
+            $(".card-body-new-add").fadeOut(500);
+            $(".card-body-new-add .form-control").attr('disabled', 'disabled');
+            $("#addressCard_{{ $address->id }} .form-control").removeAttr('disabled');
+        }
+
+        $('#contact_notice_{{ $address->id }}').hide();
+        $('.address-contact-notice').hide();
+        /* ---- */
+        $('.courier-info').hide();
+        /* ---- */
+
+    });
+
+    $("#save-address").on('click', function(e){
+
+        $(this).val('true');
+
+    });
+
+    $("#addressRadio_new").on('click', function(e){
+        $('.address-contact-notice').hide();
+
+        if($('.new-address').attr('checked', 'true')){
+            $(".card-body-new-add").fadeIn(500);
+            $(".card-body-new-add .form-control").removeAttr('disabled');
+            $(".card-body-old-add .form-control").attr('disabled', 'disabled');
+        }else{
+            $(".card-body-new-add").fadeOut(500);
+            $(".card-body-new-add .form-control").attr('disabled', 'disabled');
+        }
+    });
+</script>
+@endforeach
+@endauth
+
 @endpush


### PR DESCRIPTION
Si el cliente tiene dadas de alta direcciones al momento de ingresar al checkout los inputs de estas direcciones estarán con el atributo 'disabled' ya que despliega de primera instancia el crear una nueva dirección. Si el cliente decide elegir una de las direcciones guardadas los inputs de creación se les añade el atributo disabled y a las de la dirección se les elimina. 

De igual manera se habilito el guardar la dirección para despues si el cliente da click en checbox que habilita esta función.